### PR TITLE
Fixed ALW_PhotonModulator errors

### DIFF
--- a/Defs/Guns.xml
+++ b/Defs/Guns.xml
@@ -472,6 +472,8 @@
       </li>
     </tools>
     <comps Inherit="False">
+      <li Class="CompProperties_Forbiddable"/>      
+      <li Class="CompProperties_Styleable"></li>
       <li Class="MVCF.Comps.CompProperties_VerbProps">
         <compClass>CompEquippable</compClass>
         <verbProps>


### PR DESCRIPTION
Fixed ALW_PhotonModulator error relating to CompStyleable
Added CompProperties_Forbiddable to ALW_PhotonModulator so it can be forbiddable